### PR TITLE
Fix frameloop timer setting

### DIFF
--- a/sdlarch.c
+++ b/sdlarch.c
@@ -587,7 +587,7 @@ static bool core_environment(unsigned cmd, void *data) {
         const struct retro_frame_time_callback *frame_time =
             (const struct retro_frame_time_callback*)data;
         runloop_frame_time = *frame_time;
-        break;
+        return true;
     }
     case RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK: {
         struct retro_audio_callback *audio_cb = (struct retro_audio_callback*)data;


### PR DESCRIPTION
Should return true when successfully acting on a environment cal.