### PR TITLE
Makefile for OSX with clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
+UNAME_S := $(shell uname -s)
 target   := sdlarch
 sources  := sdlarch.c glad.c
 CFLAGS   := -Wall -g
+ifeq ($(UNAME_S),Darwin)
+LFLAGS   := -static-libstdc++
+else
 LFLAGS   := -static-libgcc
+endif
 LIBS     := 
 packages := sdl2
 


### PR DESCRIPTION
```
Darwin Humberto-MacBook-Pro.local 19.6.0 Darwin Kernel Version 19.6.0: Mon Aug 31 22:12:52 PDT 2020; root:xnu-6153.141.2~1/RELEASE_X86_64 x86_64
humbertodias@Humbertos-MacBook-Pro sdlarch % make
cc -Wall -g -D_THREAD_SAFE -I/usr/local/include/SDL2 -c -MMD -o build/sdlarch.o sdlarch.c
cc -Wall -g -D_THREAD_SAFE -I/usr/local/include/SDL2 -c -MMD -o build/glad.o glad.c
cc -static-libstdc++ -L/usr/local/lib -o sdlarch build/sdlarch.o build/glad.o  -lSDL2
humbertodias@Humbertos-MacBook-Pro sdlarch % ./sdlarch
usage: ./sdlarch <core> [game]
````
